### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/skyfield/tests/test_keplerian.py
+++ b/skyfield/tests/test_keplerian.py
@@ -34,12 +34,12 @@ def test_instantiate_8077_hoyle():
                             hoyle_8077['mean_anomaly'],
                             hoyle_8077['epoch'])
 
-    assert hoyle != None
+    assert hoyle is not None
 
 def test_instantiate_coordinates():
     coords = ICRCoordinates(x=500.25, y=10.76, z=0.1125)
 
-    assert coords != None
+    assert coords is not None
 
 def test_coordinatesEquivalence():
     coords_the_first = ICRCoordinates(x=500.25, y=10.76, z=0.1125)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:proinsias:python-skyfield?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:proinsias:python-skyfield?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)